### PR TITLE
libfdk_aac outputs m4a extension

### DIFF
--- a/flac2all_pkg/ffmpeg.py
+++ b/flac2all_pkg/ffmpeg.py
@@ -62,7 +62,7 @@ class ffmpeg:
             "libshine": "mp3",
             "opus": "opus",
             "libopus": "opus",
-            "libfdk_aac": "aac",
+            "libfdk_aac": "m4a",
             "aac": "aac",
         }
         if self.audio_codec in codectable:


### PR DESCRIPTION
When using libfdk_aac, output an m4a container rather than aac, to allow for embedded album art.

This works for instance if you set '-c:v copy' on ffmpeg. As it stands, when using just the aac extension the embedded art is not copied over.